### PR TITLE
Issue tracker requests

### DIFF
--- a/AnyDiff/AnyDiff.Tests/AnyDiff.Tests.csproj
+++ b/AnyDiff/AnyDiff.Tests/AnyDiff.Tests.csproj
@@ -23,6 +23,7 @@
 
   <ItemGroup>
     <PackageReference Include="Appveyor.TestLogger" Version="2.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.12.0" />
     <PackageReference Include="TypeSupport" Version="1.0.90" />

--- a/AnyDiff/AnyDiff.Tests/CollectionTests.cs
+++ b/AnyDiff/AnyDiff.Tests/CollectionTests.cs
@@ -69,6 +69,28 @@ namespace AnyDiff.Tests
         }
 
         [Test]
+        public void ShouldBeEqual_EmptyList_Null()
+        {
+            var provider = new DiffProvider();
+
+            var obj1 = new TestObject { IntCollection = new List<int> { } };
+            var obj2 = new TestObject { IntCollection = null };
+            var diff = provider.ComputeDiff<TestObject>(obj1, obj2, ComparisonOptions.All | ComparisonOptions.TreatEmptyListAndNullTheSame);
+            Assert.AreEqual(0, diff.Count);
+        }
+
+        [Test]
+        public void ShouldNotBeEqual_EmptyList_Null()
+        {
+            var provider = new DiffProvider();
+
+            var obj1 = new TestObject { IntCollection = new List<int> { } };
+            var obj2 = new TestObject { IntCollection = null };
+            var diff = provider.ComputeDiff<TestObject>(obj1, obj2, ComparisonOptions.All);
+            Assert.AreEqual(1, diff.Count);
+        }
+
+        [Test]
         public void ShouldDetect_List_NoDifferences()
         {
             var provider = new DiffProvider();

--- a/AnyDiff/AnyDiff.Tests/ExternalObjectTests.cs
+++ b/AnyDiff/AnyDiff.Tests/ExternalObjectTests.cs
@@ -1,5 +1,7 @@
 ﻿using NUnit.Framework;
 using System.Drawing;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 
 namespace AnyDiff.Tests
 {
@@ -46,6 +48,13 @@ namespace AnyDiff.Tests
             Assert.AreEqual(1, diff.Count);
         }
 
-        
+        [Test]
+        public void ShouldDiff_JToken()
+        {
+            var obj1 = JToken.Parse(@"{ ""list"": [""test1"", ""test2""] }");
+            var obj2 = JToken.Parse(@"{ ""list"": [""test3"", ""test4""] }");
+            var diff = AnyDiff.Diff(obj1, obj2);
+            Assert.AreEqual(4, diff.Count);
+        }
     }
 }

--- a/AnyDiff/AnyDiff.Tests/IgnoreTests.cs
+++ b/AnyDiff/AnyDiff.Tests/IgnoreTests.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using AnyDiff;
 using AnyDiff.Extensions;
 using AnyDiff.Tests.TestObjects;
 using NUnit.Framework;
@@ -192,6 +191,28 @@ namespace AnyDiff.Tests
 
             var diff = object1.Diff(object2, ComparisonOptions.All | ComparisonOptions.DisableIgnoreAttributes);
             Assert.AreEqual(1, diff.Count);
+        }
+
+        [Test]
+        public void Should_IgnoreByCustomAttribute()
+        {
+            var object1 = new CustomAttributeObject(1, "A string");
+            var object2 = new CustomAttributeObject(1, "A different string");
+
+            var diffOptions = new DiffOptions(new List<object> { typeof(System.ComponentModel.DescriptionAttribute) });
+            var diff = object1.Diff(object2, ComparisonOptions.All, diffOptions);
+            Assert.AreEqual(0, diff.Count);
+        }
+
+        [Test]
+        public void Should_IgnoreByCustomAttributeName()
+        {
+            var object1 = new CustomAttributeObject(1, "A string");
+            var object2 = new CustomAttributeObject(1, "A different string");
+
+            var diffOptions = new DiffOptions(new List<object> { "DescriptionAttribute" });
+            var diff = object1.Diff(object2, ComparisonOptions.All, diffOptions);
+            Assert.AreEqual(0, diff.Count);
         }
     }
 }

--- a/AnyDiff/AnyDiff.Tests/TestObjects/CustomAttributeObject.cs
+++ b/AnyDiff/AnyDiff.Tests/TestObjects/CustomAttributeObject.cs
@@ -1,0 +1,18 @@
+﻿using System.ComponentModel;
+
+namespace AnyDiff.Tests.TestObjects
+{
+    public class CustomAttributeObject
+    {
+        public int Id { get; set; }
+
+        [Description("This property will be ignored")]
+        public string Name { get; set; }
+
+        public CustomAttributeObject(int id, string name)
+        {
+            Id = id;
+            Name = name;
+        }
+    }
+}

--- a/AnyDiff/AnyDiff/AnyDiff.cs
+++ b/AnyDiff/AnyDiff/AnyDiff.cs
@@ -27,12 +27,39 @@ namespace AnyDiff
         /// </summary>
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff(object left, object right, ComparisonOptions options)
+        public static ICollection<Difference> Diff(object left, object right, DiffOptions diffOptions)
         {
             var diffProvider = new DiffProvider();
-            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, options);
+            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, ComparisonOptions.All, diffOptions);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff(object left, object right, ComparisonOptions comparisonOptions)
+        {
+            var diffProvider = new DiffProvider();
+            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff(object left, object right, ComparisonOptions comparisonOptions, DiffOptions diffOptions)
+        {
+            var diffProvider = new DiffProvider();
+            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, diffOptions);
         }
 
         /// <summary>
@@ -41,12 +68,12 @@ namespace AnyDiff
         /// <typeparam name="T"></typeparam>
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff<T>(T left, T right, ComparisonOptions options)
+        public static ICollection<Difference> Diff<T>(T left, T right, ComparisonOptions comparisonOptions)
         {
             var diffProvider = new DiffProvider();
-            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, options, null);
+            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions);
         }
 
         /// <summary>
@@ -55,13 +82,28 @@ namespace AnyDiff
         /// <typeparam name="T"></typeparam>
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff<T>(T left, T right, ComparisonOptions comparisonOptions, DiffOptions diffOptions)
+        {
+            var diffProvider = new DiffProvider();
+            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, diffOptions);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
         /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff<T>(T left, T right, ComparisonOptions options, string[] propertyList)
+        public static ICollection<Difference> Diff<T>(T left, T right, ComparisonOptions comparisonOptions, string[] propertyList)
         {
             var diffProvider = new DiffProvider();
-            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, options, propertyList);
+            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, DiffOptions.Default, propertyList);
         }
 
         /// <summary>
@@ -70,13 +112,45 @@ namespace AnyDiff
         /// <typeparam name="T"></typeparam>
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
         /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff<T>(T left, T right, ComparisonOptions options, params Expression<Func<T, object>>[] propertyList)
+        public static ICollection<Difference> Diff<T>(T left, T right, ComparisonOptions comparisonOptions, DiffOptions diffOptions, string[] propertyList)
         {
             var diffProvider = new DiffProvider();
-            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, options, propertyList);
+            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, diffOptions, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff<T>(T left, T right, ComparisonOptions comparisonOptions, params Expression<Func<T, object>>[] propertyList)
+        {
+            var diffProvider = new DiffProvider();
+            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff<T>(T left, T right, ComparisonOptions comparisonOptions, DiffOptions diffOptions, params Expression<Func<T, object>>[] propertyList)
+        {
+            var diffProvider = new DiffProvider();
+            return diffProvider.ComputeDiff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, diffOptions, propertyList);
         }
 
         /// <summary>
@@ -85,13 +159,29 @@ namespace AnyDiff
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
         /// <param name="maxDepth">Maximum recursion depth</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
         /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff(object left, object right, int maxDepth, ComparisonOptions options, params string[] propertyList)
+        public static ICollection<Difference> Diff(object left, object right, int maxDepth, ComparisonOptions comparisonOptions, params string[] propertyList)
         {
             var diffProvider = new DiffProvider();
-            return diffProvider.ComputeDiff(left, right, maxDepth, options, propertyList);
+            return diffProvider.ComputeDiff(left, right, maxDepth, comparisonOptions, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="maxDepth">Maximum recursion depth</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff(object left, object right, int maxDepth, ComparisonOptions comparisonOptions, DiffOptions diffOptions, params string[] propertyList)
+        {
+            var diffProvider = new DiffProvider();
+            return diffProvider.ComputeDiff(left, right, maxDepth, comparisonOptions, diffOptions, propertyList);
         }
 
         /// <summary>
@@ -101,13 +191,30 @@ namespace AnyDiff
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
         /// <param name="maxDepth">Maximum recursion depth</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
         /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff<T>(T left, T right, int maxDepth, ComparisonOptions options, params Expression<Func<T, object>>[] propertyList)
+        public static ICollection<Difference> Diff<T>(T left, T right, int maxDepth, ComparisonOptions comparisonOptions, params Expression<Func<T, object>>[] propertyList)
         {
             var diffProvider = new DiffProvider();
-            return diffProvider.ComputeDiff(left, right, maxDepth, options, propertyList);
+            return diffProvider.ComputeDiff(left, right, maxDepth, comparisonOptions, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="maxDepth">Maximum recursion depth</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff<T>(T left, T right, int maxDepth, ComparisonOptions comparisonOptions, DiffOptions diffOptions, params Expression<Func<T, object>>[] propertyList)
+        {
+            var diffProvider = new DiffProvider();
+            return diffProvider.ComputeDiff(left, right, maxDepth, comparisonOptions, diffOptions, propertyList);
         }
     }
 }

--- a/AnyDiff/AnyDiff/ComparisonOptions.cs
+++ b/AnyDiff/AnyDiff/ComparisonOptions.cs
@@ -49,6 +49,10 @@ namespace AnyDiff
         /// </summary>
         IncludeListNoInheritance = 512,
         /// <summary>
+        /// Specify that an empty list and a null list would be an equal comparison
+        /// </summary>
+        TreatEmptyListAndNullTheSame = 1024,
+        /// <summary>
         /// Compare all objects
         /// </summary>
         All = CompareProperties | CompareFields | CompareCollections,

--- a/AnyDiff/AnyDiff/DiffOptions.cs
+++ b/AnyDiff/AnyDiff/DiffOptions.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace AnyDiff
+{
+    public class DiffOptions
+    {
+        /// <summary>
+        /// The list of attributes (or names of attributes) to use when ignoring fields/properties
+        /// </summary>
+        internal static readonly ICollection<object> _defaultIgnoreAttributes = new List<object> {
+            typeof(IgnoreDataMemberAttribute),
+            typeof(NonSerializedAttribute),
+            "JsonIgnoreAttribute",
+        };
+
+        /// <summary>
+        /// An list of custom attributes that will be treated as ignore attributes
+        /// </summary>
+        public ICollection<object> AttributeIgnoreList { get; set; } = _defaultIgnoreAttributes;
+
+        public DiffOptions()
+        {
+        }
+
+        /// <summary>
+        /// Create Diff Options
+        /// </summary>
+        /// <param name="attributeIgnoreList">A list of custom attribute types or attribute names to ignore. Example: new List<object> { typeof(IgnoreDataMemberAttribute), "JsonIgnoreAttribute" }</param>
+        public DiffOptions(ICollection<object> attributeIgnoreList)
+        {
+            AttributeIgnoreList = attributeIgnoreList;
+        }
+
+        /// <summary>
+        /// Default DiffOptions
+        /// </summary>
+        public static DiffOptions Default
+        {
+            get {
+                return new DiffOptions();
+            }
+        }
+    }
+}

--- a/AnyDiff/AnyDiff/ExpressionManager.cs
+++ b/AnyDiff/AnyDiff/ExpressionManager.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 

--- a/AnyDiff/AnyDiff/Extensions/Extensions.cs
+++ b/AnyDiff/AnyDiff/Extensions/Extensions.cs
@@ -22,11 +22,11 @@ namespace AnyDiff.Extensions
         /// </summary>
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff(this object left, object right, ComparisonOptions options)
+        public static ICollection<Difference> Diff(this object left, object right, DiffOptions diffOptions)
         {
-            return Diff(left, right, DiffProvider.DefaultMaxDepth, options);
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, ComparisonOptions.All, diffOptions);
         }
 
         /// <summary>
@@ -34,12 +34,51 @@ namespace AnyDiff.Extensions
         /// </summary>
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff(this object left, object right, ComparisonOptions comparisonOptions)
+        {
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff(this object left, object right, ComparisonOptions comparisonOptions, DiffOptions diffOptions)
+        {
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, diffOptions);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
         /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff(this object left, object right, ComparisonOptions options, params string[] propertyList)
+        public static ICollection<Difference> Diff(this object left, object right, ComparisonOptions comparisonOptions, params string[] propertyList)
         {
-            return Diff(left, right, DiffProvider.DefaultMaxDepth, options, propertyList);
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, DiffOptions.Default, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff(this object left, object right, ComparisonOptions comparisonOptions, DiffOptions diffOptions, params string[] propertyList)
+        {
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, diffOptions, propertyList);
         }
 
         /// <summary>
@@ -51,7 +90,20 @@ namespace AnyDiff.Extensions
         /// <returns></returns>
         public static ICollection<Difference> Diff(this object left, object right, params string[] propertyList)
         {
-            return Diff(left, right, DiffProvider.DefaultMaxDepth, ComparisonOptions.All, propertyList);
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, ComparisonOptions.All, DiffOptions.Default, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff(this object left, object right, DiffOptions diffOptions, params string[] propertyList)
+        {
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, ComparisonOptions.All, diffOptions, propertyList);
         }
 
         /// <summary>
@@ -64,7 +116,7 @@ namespace AnyDiff.Extensions
         /// <returns></returns>
         public static ICollection<Difference> Diff<T>(this T left, T right, params Expression<Func<T, object>>[] propertyList)
         {
-            return Diff(left, right, DiffProvider.DefaultMaxDepth, ComparisonOptions.All, propertyList);
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, ComparisonOptions.All, DiffOptions.Default, propertyList);
         }
 
         /// <summary>
@@ -73,12 +125,42 @@ namespace AnyDiff.Extensions
         /// <typeparam name="T"></typeparam>
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
         /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff<T>(this T left, T right, ComparisonOptions options, params Expression<Func<T, object>>[] propertyList)
+        public static ICollection<Difference> Diff<T>(this T left, T right, DiffOptions diffOptions, params Expression<Func<T, object>>[] propertyList)
         {
-            return Diff(left, right, DiffProvider.DefaultMaxDepth, options, propertyList);
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, ComparisonOptions.All, diffOptions, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff<T>(this T left, T right, ComparisonOptions comparisonOptions, params Expression<Func<T, object>>[] propertyList)
+        {
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, DiffOptions.Default, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff<T>(this T left, T right, ComparisonOptions comparisonOptions, DiffOptions diffOptions, params Expression<Func<T, object>>[] propertyList)
+        {
+            return Diff(left, right, DiffProvider.DefaultMaxDepth, comparisonOptions, diffOptions, propertyList);
         }
 
         /// <summary>
@@ -87,13 +169,29 @@ namespace AnyDiff.Extensions
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
         /// <param name="maxDepth">Maximum recursion depth</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
         /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff(this object left, object right, int maxDepth, ComparisonOptions options, params string[] propertyList)
+        public static ICollection<Difference> Diff(this object left, object right, int maxDepth, ComparisonOptions comparisonOptions, params string[] propertyList)
         {
             var diffProvider = new DiffProvider();
-            return diffProvider.ComputeDiff(left, right, maxDepth, options, propertyList);
+            return diffProvider.ComputeDiff(left, right, maxDepth, comparisonOptions, DiffOptions.Default, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="maxDepth">Maximum recursion depth</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff(this object left, object right, int maxDepth, ComparisonOptions comparisonOptions, DiffOptions diffOptions, params string[] propertyList)
+        {
+            var diffProvider = new DiffProvider();
+            return diffProvider.ComputeDiff(left, right, maxDepth, comparisonOptions, diffOptions, propertyList);
         }
 
         /// <summary>
@@ -103,13 +201,30 @@ namespace AnyDiff.Extensions
         /// <param name="left">Object A</param>
         /// <param name="right">Object B</param>
         /// <param name="maxDepth">Maximum recursion depth</param>
-        /// <param name="options">Specify the comparison options</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
         /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
         /// <returns></returns>
-        public static ICollection<Difference> Diff<T>(this T left, T right, int maxDepth, ComparisonOptions options, params Expression<Func<T, object>>[] propertyList)
+        public static ICollection<Difference> Diff<T>(this T left, T right, int maxDepth, ComparisonOptions comparisonOptions, params Expression<Func<T, object>>[] propertyList)
         {
             var diffProvider = new DiffProvider();
-            return diffProvider.ComputeDiff(left, right, maxDepth, options, propertyList);
+            return diffProvider.ComputeDiff(left, right, maxDepth, comparisonOptions, propertyList);
+        }
+
+        /// <summary>
+        /// Compare two objects for value differences
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="left">Object A</param>
+        /// <param name="right">Object B</param>
+        /// <param name="maxDepth">Maximum recursion depth</param>
+        /// <param name="comparisonOptions">Specify the comparison options</param>
+        /// <param name="diffOptions">Specify custom diff options</param>
+        /// <param name="propertyList">A list of property names or full path names to include/exclude</param>
+        /// <returns></returns>
+        public static ICollection<Difference> Diff<T>(this T left, T right, int maxDepth, ComparisonOptions comparisonOptions, DiffOptions diffOptions, params Expression<Func<T, object>>[] propertyList)
+        {
+            var diffProvider = new DiffProvider();
+            return diffProvider.ComputeDiff(left, right, maxDepth, comparisonOptions, diffOptions, propertyList);
         }
     }
 }


### PR DESCRIPTION
This fixes several separate issues:

- Optionally allow empty lists to be treated the same as null lists (using `ComparisonOptions.TreatEmptyListAndNullTheSame`). 
- Optionally allow custom ignore attributes to be passed in (via `DiffOptions`). 
- Allow support for enumerating Newtonsoft JTokens, or any custom implemented IEnumerable

Fixes #4 , Fixes #5 , Fixes #6 
