### PR TITLE
Fix for stopping recurse into types that share the same base type. 

### DIFF
--- a/AnyDiff/AnyDiff.Tests/AbstractTypeTests.cs
+++ b/AnyDiff/AnyDiff.Tests/AbstractTypeTests.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Linq;
+using AnyDiff.Tests.TestObjects;
+using AnyDiff.Tests.TestObjects.Abstract;
+using NUnit.Framework;
+
+namespace AnyDiff.Tests
+{
+    [TestFixture]
+    public class AbstractTypeTests
+    {
+        [Test]
+        public void If_BaseType_Is_Abstract_And_Both_Objects_Implement_Then_Should_Emit_Whole_Object_If_Types_Different()
+        {
+
+                var provider = new DiffProvider();
+
+                var obj1 = new TypeWithAbstractProperty { Id = "1", AbstractProp = new AbstractImplementation1() };
+                var obj2 = new TypeWithAbstractProperty { Id = "1", AbstractProp = new AbstractImplementation2() };
+                var diff = provider.ComputeDiff(obj1, obj2,ComparisonOptions.All | ComparisonOptions.AllowCompareDifferentObjects);
+                Assert.AreEqual(1, diff.Count);
+
+        }
+    }
+}

--- a/AnyDiff/AnyDiff.Tests/TestObjects/Abstract/AbstractObject.cs
+++ b/AnyDiff/AnyDiff.Tests/TestObjects/Abstract/AbstractObject.cs
@@ -1,0 +1,29 @@
+﻿namespace AnyDiff.Tests.TestObjects.Abstract
+{
+    public abstract class AbstractObject
+    {
+        public virtual string Type
+        {
+            get => GetType().Name.ToLower();
+            set {}
+        }
+    }
+
+    public class AbstractImplementation1 : AbstractObject
+    {
+        public string Property1 { get; }
+        public int Property2 { get; }
+    }
+
+    public class AbstractImplementation2 : AbstractObject
+    {
+        public string Property2 { get; }
+        public int Property3 { get; }
+    }
+
+    public class TypeWithAbstractProperty
+    {
+        public string Id { get; set;  }
+        public AbstractObject AbstractProp { get; set; }
+    }
+}

--- a/AnyDiff/AnyDiff/DiffProvider.cs
+++ b/AnyDiff/AnyDiff/DiffProvider.cs
@@ -536,7 +536,14 @@ namespace AnyDiff
             }
             else if (!leftValueType.IsValueType && leftValueType != typeof(string))
             {
-                differences = RecurseProperties(leftValue, rightValue, leftValue, differences, currentDepth, maxDepth, objectTree, path, options, propertiesToExcludeOrInclude, diffOptions);
+                if (leftValueType != rightValueType && leftValueType.BaseType == rightValueType.BaseType)
+                {
+                    differences.Add(new Difference(propertyType, propertyName, path, leftValue, rightValue, typeConverter));
+                }
+                else
+                {
+                    differences = RecurseProperties(leftValue, rightValue, leftValue, differences, currentDepth, maxDepth, objectTree, path, options, propertiesToExcludeOrInclude, diffOptions);
+                }
             }
             else
             {


### PR DESCRIPTION
Firstly thanks so much for this library. I have rolled my own libs for the doing this so many times. But never been able to open source due "evil" corporation policies. 

This PR fixes a bug when `ComparisonOptions.AllowCompareDifferentObjects` is specified and the comparing objects have the same base type (abstract or not). 

The current behaviour means that the two objects get into which leads to a lot of spurious differences when really you are just interested in the entire object tree. 